### PR TITLE
WIP: Support SSE transport in openapi-mcp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,16 @@ You can say:
 
 2. **Restart Claude Desktop** and start interacting with your API!
 
+## Running the server over SSE
+
+To run the server over SSE, use the `--sse` flag when starting the server:
+
+```bash
+npx openapi-mcp-server /abs/path/to/petstore-openapi.json --sse
+```
+
+This will start the server and listen for SSE connections on the specified port (default is 3001). You can then connect to the server using an SSE client.
+
 ## Examples
 
 This repository includes a complete example of a Petstore API server that you can use to test the OpenAPI MCP Server. The example server implements a basic CRUD API for managing pets, making it perfect for learning how to use this tool.

--- a/src/mcp/proxy.ts
+++ b/src/mcp/proxy.ts
@@ -24,7 +24,7 @@ type NewToolDefinition = {
 }
 
 export class MCPProxy {
-  private server: Server
+  public server: Server
   private httpClient: HttpClient
   private tools: Record<string, NewToolDefinition>
   private openApiLookup: Record<string, OpenAPIV3.OperationObject & { method: string; path: string }>
@@ -160,10 +160,5 @@ export class MCPProxy {
       return name;
     }
     return name.slice(0, 64);
-  }
-
-  async connect(transport: Transport) {
-    // The SDK will handle stdio communication
-    await this.server.connect(transport)
   }
 }


### PR DESCRIPTION
Fixes #14

Add support for SSE transport in the server.

* Import `SSEServerTransport` from `@modelcontextprotocol/sdk/server/sse.js` in `scripts/start-proxy.ts`.
* Add a new flag `--sse` to handle SSE transport connections in `scripts/start-proxy.ts`.
* Modify the `startProxy` function in `scripts/start-proxy.ts` to handle both STDIO and SSE transports.
* Update `MCPProxy` class in `src/mcp/proxy.ts` to make the `server` property public.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/snaggle-ai/openapi-mcp-server/pull/15?shareId=79bc0f27-5591-4596-b672-b28fd9b0fb76).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added guidance on running the server with Server-Sent Events (SSE), including a command-line example for real-time updates.
- **New Features**
	- Enabled a new SSE mode for the proxy server, allowing live server-to-client communication via an added command-line flag.
- **Refactor**
	- Updated server connection handling for more streamlined operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->